### PR TITLE
patch to add ligature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,19 +25,21 @@ dependencies = [
  "crossfont",
  "dirs",
  "embed-resource",
- "fnv",
  "gl_generator",
  "glutin",
  "libc",
+ "linked-hash-map",
  "log",
  "notify",
  "objc",
  "parking_lot",
  "png",
  "raw-window-handle",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin_sleep",
  "time",
  "unicode-width",
  "urlocator",
@@ -105,15 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,9 +172,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "calloop"
@@ -222,17 +215,34 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -392,6 +402,18 @@ dependencies = [
 
 [[package]]
 name = "core-text"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131b3fd1f8bd5db9f2b398fa4fdb6008c64afc04d447c306ac2c7e98fba2a61d"
+dependencies = [
+ "core-foundation 0.7.0",
+ "core-graphics 0.19.2",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
 version = "19.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c7f46e8b820fd5f4b28528104b28b0a91cbe9e9c5bde8017087fb44bc93a60"
@@ -438,22 +460,23 @@ dependencies = [
 [[package]]
 name = "crossfont"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108946cf5228893bf470564410639b87a53f959d937f1c57bbc2a6603d98e812"
+source = "git+https://github.com/zenixls2/crossfont?branch=ligature#5c6d16d03cf3cd4275873acec47ea6c8fcae3f6f"
 dependencies = [
  "cocoa 0.24.0",
  "core-foundation 0.9.1",
  "core-foundation-sys 0.8.2",
  "core-graphics 0.22.2",
- "core-text",
+ "core-text 19.1.0",
  "dwrote",
  "foreign-types 0.5.0",
  "freetype-rs",
+ "harfbuzz_rs",
  "libc",
  "log",
  "pkg-config",
  "servo-fontconfig",
  "winapi 0.3.9",
+ "wio",
 ]
 
 [[package]]
@@ -493,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "derivative"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaed5874effa6cde088c644ddcdcb4ffd1511391c5be4fdd7a5ccd02c7e4a183"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -586,13 +609,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "winapi 0.3.9",
 ]
 
@@ -643,6 +666,15 @@ name = "foreign-types-shared"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
+
+[[package]]
+name = "freetype"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73222ab32d9ad65fe0e1c3258da8d614fd47cf19fce92b09eb520060c5c5ad5"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "freetype-rs"
@@ -796,10 +828,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.17"
+name = "harfbuzz-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "845f3e65ec4e30b0b1b6e1c055900871f3776d3492cc76744e3fc5943a6129a9"
+dependencies = [
+ "cc",
+ "core-graphics 0.19.2",
+ "core-text 15.0.0",
+ "foreign-types 0.3.2",
+ "freetype",
+ "pkg-config",
+]
+
+[[package]]
+name = "harfbuzz_rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5bba81dd6b356135f0b31c42447e49d45116adc2e02910070947a322c423aa5"
+dependencies = [
+ "bitflags",
+ "harfbuzz-sys",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -809,6 +880,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "inotify"
@@ -823,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
@@ -896,15 +977,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "7eb0c4e9c72ee9d69b767adebc5f4788462a3b45624acd919475c92597bcaf4f"
 
 [[package]]
 name = "libloading"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -912,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -927,11 +1008,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
 ]
 
@@ -1109,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
+checksum = "ab6f70b46d6325aa300f1c7bb3d470127dfc27806d8ea6bf294ee0ce643ce2b1"
 dependencies = [
  "memchr",
  "version_check",
@@ -1193,6 +1274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "osmesa-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,7 +1317,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1268,6 +1355,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,13 +1412,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -1323,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rust-argon2"
@@ -1338,6 +1458,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rusttype"
@@ -1378,18 +1504,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1478,9 +1604,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -1523,16 +1649,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin_sleep"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a98101bdc3833e192713c2af0b0dd2614f50d1cf1f7a97c5221b7aac052acc7"
+dependencies = [
+ "once_cell",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "spsc-buffer"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be6c3f39c37a4283ee4b43d1311c828f2e1fb0541e76ea0cb1a2abd9ef2f5b3b"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -1541,10 +1671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
-name = "syn"
-version = "1.0.58"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1552,10 +1688,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -1605,6 +1750,12 @@ name = "ttf-parser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e5d7cd7ab3e47dda6e56542f4bbf3824c15234958c6e1bd6aaa347e93499fdc"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 lto = true
 debug = 1
 incremental = false
+
+[patch.crates-io]
+crossfont = { git = "https://github.com/zenixls2/crossfont", branch = "ligature", features = ["force_system_fontconfig"] }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -11,6 +11,11 @@
 #import:
 #  - /path/to/alacritty.yml
 
+
+# This value is used to decide whether to show FPS in title bar or not.
+# By default, it's set to false
+#fps: false
+
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables
 # set by alacritty itself.
@@ -171,6 +176,10 @@
   # Thin strokes are suitable for retina displays, but for non-retina screens
   # it is recommended to set `use_thin_strokes` to `false`.
   #use_thin_strokes: true
+
+  # Choose whether to enable ligature (Currently only in Linux, may work in macOS)
+  # by default it's true (enabled)
+  #ligatures: true
 
 # If `true`, bold text is drawn using the bright color variants.
 #draw_bold_text_with_bright_colors: false

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -18,10 +18,9 @@ path = "../alacritty_config_derive"
 version = "0.1.0"
 
 [dependencies]
-clap = "2"
+clap = "3.0.0-beta.2"
 log = { version = "0.4", features = ["std", "serde"] }
 time = "0.1.40"
-fnv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1"
@@ -35,6 +34,9 @@ libc = "0.2"
 unicode-width = "0.1"
 bitflags = "1"
 dirs = "2.0.2"
+rustc-hash = "1.1.0"
+linked-hash-map = "0.5.3"
+spin_sleep = "1.0.0"
 
 [build-dependencies]
 gl_generator = "0.14.0"

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -68,75 +68,70 @@ impl Options {
             .version(version.as_str())
             .author(crate_authors!("\n"))
             .about(crate_description!())
-            .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))
+            .arg(Arg::new("ref-test").long("ref-test").about("Generates ref test"))
+            .arg(Arg::new("print-events").long("print-events").about("Print all events to stdout"))
             .arg(
-                Arg::with_name("print-events")
-                    .long("print-events")
-                    .help("Print all events to stdout"),
-            )
-            .arg(
-                Arg::with_name("title")
+                Arg::new("title")
                     .long("title")
-                    .short("t")
+                    .short('t')
                     .takes_value(true)
-                    .help(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
+                    .about(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
             )
             .arg(
-                Arg::with_name("class")
+                Arg::new("class")
                     .long("class")
                     .value_name("instance> | <instance>,<general")
                     .takes_value(true)
                     .use_delimiter(true)
-                    .help(&format!(
+                    .about(&format!(
                         "Defines window class/app_id on X11/Wayland [default: {}]",
                         DEFAULT_NAME
                     )),
             )
-            .arg(
-                Arg::with_name("embed").long("embed").takes_value(true).help(
-                    "Defines the X11 window ID (as a decimal integer) to embed Alacritty within",
-                ),
-            )
-            .arg(
-                Arg::with_name("q")
-                    .short("q")
-                    .multiple(true)
-                    .conflicts_with("v")
-                    .help("Reduces the level of verbosity (the min level is -qq)"),
-            )
-            .arg(
-                Arg::with_name("v")
-                    .short("v")
-                    .multiple(true)
-                    .conflicts_with("q")
-                    .help("Increases the level of verbosity (the max level is -vvv)"),
-            )
-            .arg(
-                Arg::with_name("working-directory")
-                    .long("working-directory")
-                    .takes_value(true)
-                    .help("Start the shell in the specified working directory"),
-            )
-            .arg(Arg::with_name("config-file").long("config-file").takes_value(true).help(
-                &format!("Specify alternative configuration file [default: {}]", CONFIG_PATH),
+            .arg(Arg::new("embed").long("embed").takes_value(true).about(
+                "Defines the X11 window ID (as a decimal integer) to embed Alacritty within",
             ))
             .arg(
-                Arg::with_name("command")
+                Arg::new("q")
+                    .short('q')
+                    .multiple(true)
+                    .conflicts_with("v")
+                    .about("Reduces the level of verbosity (the min level is -qq)"),
+            )
+            .arg(
+                Arg::new("v")
+                    .short('v')
+                    .multiple(true)
+                    .conflicts_with("q")
+                    .about("Increases the level of verbosity (the max level is -vvv)"),
+            )
+            .arg(
+                Arg::new("working-directory")
+                    .long("working-directory")
+                    .takes_value(true)
+                    .about("Start the shell in the specified working directory"),
+            )
+            .arg(Arg::new("config-file").long("config-file").takes_value(true).about(&format!(
+                "Specify alternative configuration file [default: {}]",
+                CONFIG_PATH
+            )))
+            .arg(
+                Arg::new("command")
                     .long("command")
-                    .short("e")
+                    .short('e')
                     .multiple(true)
                     .takes_value(true)
                     .allow_hyphen_values(true)
-                    .help("Command and args to execute (must be last argument)"),
+                    .about("Command and args to execute (must be last argument)"),
             )
-            .arg(Arg::with_name("hold").long("hold").help("Remain open after child process exits"))
+            .arg(Arg::new("hold").long("hold").about("Remain open after child process exits"))
             .arg(
-                Arg::with_name("option")
+                Arg::new("option")
                     .long("option")
-                    .short("o")
+                    .short('o')
                     .multiple(true)
                     .takes_value(true)
-                    .help("Override configuration file options [example: cursor.style=Beam]"),
+                    .about("Override configuration file options [example: cursor.style=Beam]"),
             )
             .get_matches();
 

--- a/alacritty/src/config/font.rs
+++ b/alacritty/src/config/font.rs
@@ -14,7 +14,7 @@ use crate::config::ui_config::Delta;
 /// field in this struct. It might be nice in the future to have defaults for
 /// each value independently. Alternatively, maybe erroring when the user
 /// doesn't provide complete config is Ok.
-#[derive(ConfigDeserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(ConfigDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Font {
     /// Extra spacing per character.
     pub offset: Delta<i8>,
@@ -38,6 +38,25 @@ pub struct Font {
 
     /// Font size in points.
     size: Size,
+
+    /// Toggles rendering of font ligatures
+    pub ligatures: bool,
+}
+
+impl Default for Font {
+    fn default() -> Font {
+        Font {
+            offset: Default::default(),
+            glyph_offset: Default::default(),
+            use_thin_strokes: false,
+            normal: Default::default(),
+            bold: Default::default(),
+            italic: Default::default(),
+            bold_italic: Default::default(),
+            size: Default::default(),
+            ligatures: true,
+        }
+    }
 }
 
 impl Font {

--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, fs, io};
 
 use log::{error, info};
@@ -123,7 +123,7 @@ pub fn load(options: &Options) -> Config {
 }
 
 /// Attempt to reload the configuration file.
-pub fn reload(config_path: &PathBuf, options: &Options) -> Result<Config> {
+pub fn reload(config_path: &Path, options: &Options) -> Result<Config> {
     // Load config, propagating errors.
     let config_options = options.config_options().clone();
     let mut config = load_from(&config_path, config_options)?;
@@ -135,7 +135,7 @@ pub fn reload(config_path: &PathBuf, options: &Options) -> Result<Config> {
 }
 
 /// Load configuration file and log errors.
-fn load_from(path: &PathBuf, cli_config: Value) -> Result<Config> {
+fn load_from(path: &Path, cli_config: Value) -> Result<Config> {
     match read_config(path, cli_config) {
         Ok(config) => Ok(config),
         Err(err) => {
@@ -146,7 +146,7 @@ fn load_from(path: &PathBuf, cli_config: Value) -> Result<Config> {
 }
 
 /// Deserialize configuration file from path.
-fn read_config(path: &PathBuf, cli_config: Value) -> Result<Config> {
+fn read_config(path: &Path, cli_config: Value) -> Result<Config> {
     let mut config_paths = Vec::new();
     let mut config_value = parse_config(&path, &mut config_paths, IMPORT_RECURSION_LIMIT)?;
 
@@ -162,7 +162,7 @@ fn read_config(path: &PathBuf, cli_config: Value) -> Result<Config> {
 
 /// Deserialize all configuration files as generic Value.
 fn parse_config(
-    path: &PathBuf,
+    path: &Path,
     config_paths: &mut Vec<PathBuf>,
     recursion_limit: usize,
 ) -> Result<Value> {

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -22,6 +22,9 @@ pub struct UIConfig {
 
     pub mouse: Mouse,
 
+    /// Show FPS in title.
+    pub fps: bool,
+
     /// Debug options.
     pub debug: Debug,
 
@@ -53,6 +56,7 @@ impl Default for UIConfig {
             font: Default::default(),
             window: Default::default(),
             mouse: Default::default(),
+            fps: false,
             debug: Default::default(),
             config_paths: Default::default(),
             key_bindings: Default::default(),

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -1,6 +1,7 @@
 //! The display subsystem including window management, font rasterization, and
 //! GPU drawing.
 
+use linked_hash_map::LinkedHashMap;
 use std::cmp::min;
 use std::f64;
 use std::fmt::{self, Formatter};
@@ -27,6 +28,7 @@ use alacritty_terminal::grid::Dimensions as _;
 use alacritty_terminal::index::{Column, Direction, Line, Point};
 use alacritty_terminal::selection::Selection;
 use alacritty_terminal::term::{SizeInfo, Term, TermMode, MIN_COLS, MIN_SCREEN_LINES};
+use alacritty_terminal::text_run::TextRun;
 
 use crate::config::font::Font;
 use crate::config::window::Dimensions;
@@ -37,7 +39,7 @@ use crate::cursor::IntoRects;
 use crate::event::{Mouse, SearchState};
 use crate::message_bar::{MessageBuffer, MessageType};
 use crate::meter::Meter;
-use crate::renderer::rects::{RenderLines, RenderRect};
+use crate::renderer::rects::RenderRect;
 use crate::renderer::{self, GlyphCache, QuadRenderer};
 use crate::url::{Url, Urls};
 use crate::window::{self, Window};
@@ -164,6 +166,7 @@ pub struct Display {
 
     renderer: QuadRenderer,
     glyph_cache: GlyphCache,
+    text_run_cache: LinkedHashMap<u64, TextRun>,
     meter: Meter,
 }
 
@@ -294,6 +297,7 @@ impl Display {
             _ => (),
         }
 
+        let cell_nums = size_info.screen_lines().0 * size_info.cols().0;
         Ok(Self {
             window,
             renderer,
@@ -307,6 +311,7 @@ impl Display {
             #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
             wayland_event_queue,
             cursor_hidden: false,
+            text_run_cache: LinkedHashMap::with_capacity(cell_nums * 2),
         })
     }
 
@@ -316,7 +321,11 @@ impl Display {
         config: &Config,
     ) -> Result<(GlyphCache, f32, f32), Error> {
         let font = config.ui_config.font.clone();
-        let rasterizer = Rasterizer::new(dpr as f32, config.ui_config.font.use_thin_strokes)?;
+        let rasterizer = Rasterizer::new(
+            dpr as f32,
+            config.ui_config.font.use_thin_strokes,
+            config.ui_config.font.ligatures,
+        )?;
 
         // Initialize glyph cache.
         let glyph_cache = {
@@ -362,6 +371,7 @@ impl Display {
         self.renderer.with_loader(|mut api| {
             cache.clear_glyph_cache(&mut api);
         });
+        self.text_run_cache.clear();
     }
 
     /// Process update events.
@@ -384,8 +394,8 @@ impl Display {
             let cell_dimensions = self.update_glyph_cache(config, font);
             cell_width = cell_dimensions.0;
             cell_height = cell_dimensions.1;
-
             info!("Cell size: {} x {}", cell_width, cell_height);
+            self.text_run_cache.clear();
         } else if update_pending.cursor_dirty() {
             self.clear_glyph_cache();
         }
@@ -428,6 +438,16 @@ impl Display {
 
         info!("Padding: {} x {}", self.size_info.padding_x(), self.size_info.padding_y());
         info!("Width: {}, Height: {}", self.size_info.width(), self.size_info.height());
+        let target_capacity = self.size_info.screen_lines().0 * self.size_info.cols().0 * 2;
+        let cache_capacity = self.text_run_cache.capacity();
+        if target_capacity > cache_capacity {
+            self.text_run_cache.reserve(target_capacity - cache_capacity);
+        } else {
+            while self.text_run_cache.len() > target_capacity {
+                self.text_run_cache.pop_front();
+            }
+            self.text_run_cache.shrink_to_fit();
+        }
     }
 
     /// Draw the screen.
@@ -449,13 +469,13 @@ impl Display {
         let viewport_match = search_state
             .focused_match()
             .and_then(|focused_match| terminal.grid().clamp_buffer_range_to_visible(focused_match));
-        let cursor_hidden = self.cursor_hidden || search_state.regex().is_some();
+        let cursor_hidden = self.cursor_hidden || search_active;
 
         // Collect renderable content before the terminal is dropped.
-        let mut content = terminal.renderable_content(config, !cursor_hidden);
-        let mut grid_cells = Vec::new();
+        let mut content = terminal.renderable_content(config, !cursor_hidden, viewport_match);
+        let mut grid_text_runs = Vec::new();
         while let Some(cell) = content.next() {
-            grid_cells.push(cell);
+            grid_text_runs.push(cell);
         }
         let cursor = content.cursor();
 
@@ -481,43 +501,64 @@ impl Display {
             api.clear(background_color);
         });
 
-        let mut lines = RenderLines::new();
         let mut urls = Urls::new();
+        let mut rects = vec![];
 
         // Draw grid.
         {
             let _sampler = self.meter.sampler();
+            let _text_run_cache = &mut self.text_run_cache;
+            let target_capacity = self.size_info.screen_lines().0 * self.size_info.cols().0 * 2;
 
             let glyph_cache = &mut self.glyph_cache;
             self.renderer.with_api(&config.ui_config, &size_info, |mut api| {
-                // Iterate over all non-empty cells in the grid.
-                for mut cell in grid_cells {
-                    // Invert the active match during search.
-                    if cell.is_match
-                        && viewport_match
-                            .as_ref()
-                            .map_or(false, |viewport_match| viewport_match.contains(&cell.point()))
-                    {
-                        let colors = config.colors.search.focused_match;
-                        let match_fg = colors.foreground.color(cell.fg, cell.bg);
-                        cell.bg = colors.background.color(cell.fg, cell.bg);
-                        cell.fg = match_fg;
-                        cell.bg_alpha = 1.0;
-                    }
-
+                let grid_length = grid_text_runs.len();
+                #[allow(unused_mut)]
+                let mut hit = 0;
+                // Iterate over all non-empty text_runs in the grid.
+                #[allow(unused_mut)]
+                for mut text_run in grid_text_runs.into_iter() {
                     // Update URL underlines.
-                    urls.update(size_info.cols(), &cell);
-
+                    urls.update(size_info.cols(), &text_run);
                     // Update underline/strikeout.
-                    lines.update(&cell);
-
-                    // Draw the cell.
-                    api.render_cell(cell, glyph_cache);
+                    rects.extend(RenderRect::all_from_text_run(&text_run, &metrics, &size_info));
+                    if config.ui_config.font.ligatures {
+                        use std::hash::{Hash, Hasher};
+                        let mut hasher = rustc_hash::FxHasher::default();
+                        text_run.hash(&mut hasher);
+                        let key = hasher.finish();
+                        if let Some(text_run_with_data) = _text_run_cache.get_refresh(&key) {
+                            if text_run.eq(text_run_with_data) {
+                                hit += 1;
+                                text_run.update_to_data(text_run_with_data);
+                                api.render_text_run_with_data(text_run_with_data, glyph_cache);
+                                continue;
+                            }
+                        }
+                        api.render_text_run_with_data(&mut text_run, glyph_cache);
+                        _text_run_cache.insert(key, text_run);
+                    } else {
+                        api.render_text_run(&text_run, glyph_cache);
+                    }
+                }
+                if config.ui_config.font.ligatures {
+                    let cache_capacity = _text_run_cache.capacity();
+                    if target_capacity > cache_capacity {
+                        _text_run_cache.reserve(target_capacity - cache_capacity);
+                    } else {
+                        while _text_run_cache.len() > target_capacity {
+                            _text_run_cache.pop_front();
+                        }
+                        _text_run_cache.shrink_to_fit();
+                    }
+                    debug!(
+                        "hit rate: {:.3}, total {}",
+                        hit as f64 / grid_length as f64,
+                        grid_length
+                    );
                 }
             });
         }
-
-        let mut rects = lines.rects(&metrics, &size_info);
 
         // Update visible URLs.
         self.urls = urls;

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::io::Write;
 use std::mem;
 use std::ops::RangeInclusive;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -955,18 +955,46 @@ impl<N: Notify + OnResize> Processor<N> {
             let event: Event = TerminalEvent::CursorBlinkingChange(true).into();
             self.event_queue.push(event.into());
         }
+        let mut loop_helper = spin_sleep::LoopHelper::builder().build_without_target_rate();
 
         event_loop.run_return(|event, event_loop, control_flow| {
             if self.config.ui_config.debug.print_events {
                 info!("glutin event: {:?}", event);
             }
 
-            // Ignore all events we do not care about.
-            if Self::skip_event(&event) {
-                return;
-            }
-
             match event {
+                GlutinEvent::WindowEvent { event, .. }
+                    if matches!(
+                        event,
+                        WindowEvent::KeyboardInput { is_synthetic: true, .. }
+                            | WindowEvent::TouchpadPressure { .. }
+                            | WindowEvent::CursorEntered { .. }
+                            | WindowEvent::AxisMotion { .. }
+                            | WindowEvent::HoveredFileCancelled
+                            | WindowEvent::Destroyed
+                            | WindowEvent::HoveredFile(_)
+                            | WindowEvent::Touch(_)
+                            | WindowEvent::Moved(_)
+                    ) =>
+                {
+                    return
+                },
+                GlutinEvent::Suspended { .. }
+                | GlutinEvent::NewEvents { .. }
+                | GlutinEvent::LoopDestroyed => return,
+                // draw fps
+                GlutinEvent::MainEventsCleared => {
+                    if self.config.ui_config.fps {
+                        if let Some(rate) = loop_helper.report_rate() {
+                            self.display.window.set_fps(rate);
+                        }
+                        loop_helper.loop_sleep();
+                        loop_helper.loop_start();
+                    } else {
+                        self.display.window.unset_fps();
+                    }
+                    return;
+                },
                 // Check for shutdown.
                 GlutinEvent::UserEvent(Event::TerminalEvent(TerminalEvent::Exit)) => {
                     *control_flow = ControlFlow::Exit;
@@ -1230,31 +1258,8 @@ impl<N: Notify + OnResize> Processor<N> {
         }
     }
 
-    /// Check if an event is irrelevant and can be skipped.
-    fn skip_event(event: &GlutinEvent<'_, Event>) -> bool {
-        match event {
-            GlutinEvent::WindowEvent { event, .. } => matches!(
-                event,
-                WindowEvent::KeyboardInput { is_synthetic: true, .. }
-                    | WindowEvent::TouchpadPressure { .. }
-                    | WindowEvent::CursorEntered { .. }
-                    | WindowEvent::AxisMotion { .. }
-                    | WindowEvent::HoveredFileCancelled
-                    | WindowEvent::Destroyed
-                    | WindowEvent::HoveredFile(_)
-                    | WindowEvent::Touch(_)
-                    | WindowEvent::Moved(_)
-            ),
-            GlutinEvent::Suspended { .. }
-            | GlutinEvent::NewEvents { .. }
-            | GlutinEvent::MainEventsCleared
-            | GlutinEvent::LoopDestroyed => true,
-            _ => false,
-        }
-    }
-
     fn reload_config<T>(
-        path: &PathBuf,
+        path: &Path,
         processor: &mut input::Processor<'_, T, ActionContext<'_, N, T>>,
     ) where
         T: EventListener,

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -14,7 +14,6 @@ compile_error!(r#"at least one of the "x11"/"wayland" features must be enabled"#
 
 #[cfg(target_os = "macos")]
 use std::env;
-use std::error::Error;
 use std::fs;
 use std::io::{self, Write};
 use std::sync::Arc;
@@ -126,7 +125,7 @@ fn run(
     window_event_loop: GlutinEventLoop<Event>,
     config: Config,
     options: Options,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), display::Error> {
     info!("Welcome to Alacritty");
 
     // Log the configuration paths.

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -33,7 +33,7 @@ signal-hook = { version = "0.1", features = ["mio-support"] }
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.3"
-winapi = { version = "0.3.7", features = [
+winapi = { version = "0.3.9", features = [
     "impl-default", "basetsd", "libloaderapi", "minwindef", "ntdef", "processthreadsapi", "winbase",
     "wincon", "wincontypes", "winerror", "winnt", "winuser",
 ]}

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -190,9 +190,9 @@ impl CursorBlinking {
     }
 }
 
-impl Into<bool> for CursorBlinking {
-    fn into(self) -> bool {
-        self == Self::On || self == Self::Always
+impl From<CursorBlinking> for bool {
+    fn from(s: CursorBlinking) -> bool {
+        s == CursorBlinking::On || s == CursorBlinking::Always
     }
 }
 

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -199,7 +199,9 @@ impl From<&RenderableCell> for Point<Line> {
 /// A line.
 ///
 /// Newtype to avoid passing values incorrectly.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd)]
+#[derive(
+    Hash, Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd,
+)]
 pub struct Line(pub usize);
 
 impl fmt::Display for Line {
@@ -211,7 +213,9 @@ impl fmt::Display for Line {
 /// A column.
 ///
 /// Newtype to avoid passing values incorrectly.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd)]
+#[derive(
+    Hash, Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd,
+)]
 pub struct Column(pub usize);
 
 impl fmt::Display for Column {

--- a/alacritty_terminal/src/lib.rs
+++ b/alacritty_terminal/src/lib.rs
@@ -13,6 +13,7 @@ pub mod index;
 pub mod selection;
 pub mod sync;
 pub mod term;
+pub mod text_run;
 pub mod thread;
 pub mod tty;
 pub mod vi_mode;

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Display, Formatter};
-use std::ops::{Add, Index, IndexMut, Mul};
+use std::ops::{Add, Div, Index, IndexMut, Mul};
 use std::str::FromStr;
 
 use log::trace;
@@ -15,7 +15,7 @@ pub const COUNT: usize = 269;
 /// Factor for automatic computation of dim colors used by terminal.
 pub const DIM_FACTOR: f32 = 0.66;
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Default, Serialize)]
+#[derive(Hash, Debug, Eq, PartialEq, Copy, Clone, Default, Serialize)]
 pub struct Rgb {
     pub r: u8,
     pub g: u8,
@@ -62,6 +62,7 @@ impl Rgb {
 impl Mul<f32> for Rgb {
     type Output = Rgb;
 
+    #[inline]
     fn mul(self, rhs: f32) -> Rgb {
         let result = Rgb {
             r: (f32::from(self.r) * rhs).max(0.0).min(255.0) as u8,
@@ -84,6 +85,24 @@ impl Add<Rgb> for Rgb {
             g: self.g.saturating_add(rhs.g),
             b: self.b.saturating_add(rhs.b),
         }
+    }
+}
+
+// A divide function for Rgb, as the default dim is just *2/3.
+impl Div<f32> for Rgb {
+    type Output = Rgb;
+
+    #[inline]
+    fn div(self, rhs: f32) -> Rgb {
+        let result = Rgb {
+            r: (f32::from(self.r) / rhs).max(0.0).min(255.0) as u8,
+            g: (f32::from(self.g) / rhs).max(0.0).min(255.0) as u8,
+            b: (f32::from(self.b) / rhs).max(0.0).min(255.0) as u8,
+        };
+
+        trace!("Shrink RGB by {} from {:?} to {:?}", rhs, self, result);
+
+        result
     }
 }
 

--- a/alacritty_terminal/src/term/search.rs
+++ b/alacritty_terminal/src/term/search.rs
@@ -15,6 +15,7 @@ const BRACKET_PAIRS: [(char, char); 4] = [('(', ')'), ('[', ']'), ('{', '}'), ('
 pub type Match = RangeInclusive<Point<usize>>;
 
 /// Terminal regex search state.
+#[derive(Clone)]
 pub struct RegexSearch {
     /// Locate end of match searching right.
     right_fdfa: DenseDFA<Vec<usize>, usize>,

--- a/alacritty_terminal/src/text_run.rs
+++ b/alacritty_terminal/src/text_run.rs
@@ -1,0 +1,173 @@
+use bitflags::bitflags;
+
+use std::cmp::{Eq, PartialEq};
+use std::hash::{Hash, Hasher};
+
+use crate::ansi::Color;
+use crate::grid::Indexed;
+use crate::index::{Column, Line, Point};
+use crate::term::cell::{Cell, Flags};
+use crate::term::color::Rgb;
+use crate::term::render::RenderableCell;
+
+#[derive(Copy, Debug, Clone, Default)]
+pub struct Glyph {
+    pub tex_id: std::os::raw::c_uint, // GLuint
+    pub multicolor: bool,
+    pub top: i16,
+    pub left: i16,
+    pub width: i16,
+    pub height: i16,
+    pub uv_bot: f32,
+    pub uv_left: f32,
+    pub uv_width: f32,
+    pub uv_height: f32,
+}
+
+bitflags! {
+    pub struct UIFlags: u8 {
+        const SELECTED       = 0b00001;
+        const SEARCH_MATCHED = 0b00010;
+        const BLOCK          = 0b00100;
+        const CURSOR         = 0b01000;
+        const FOCUSED_MATCH  = 0b10000;
+    }
+}
+
+#[derive(Debug)]
+pub struct RunStart {
+    pub line: Line,
+    pub column: Column,
+    pub fg: Color,
+    pub bg: Color,
+    pub uiflags: UIFlags,
+    pub flags: Flags,
+}
+
+impl RunStart {
+    /// Compare cell and check if it belongs to the same run.
+    #[inline]
+    pub fn belongs_to_text_run(&self, cell: &Indexed<&Cell>, uiflags: UIFlags) -> bool {
+        self.line == cell.line
+            && self.fg == cell.fg
+            && self.bg == cell.bg
+            && self.flags == cell.flags
+            && self.uiflags == uiflags
+    }
+}
+
+/// Represents a set of renderable cells that all share the same rendering properties.
+/// The assumption is that if two cells are in the same TextRun they can be sent off together to
+/// be shaped. This allows for ligatures to be rendered but not when something breaks up a ligature
+/// (e.g. selection highlight) which is desired behavior.
+#[derive(Debug)]
+pub struct TextRun {
+    /// A run never spans multiple lines.
+    pub line: Line,
+    /// Span of columns the text run covers.
+    pub span: (Column, Column),
+    /// Sequence of characters.
+    pub content: (String, Vec<Option<Vec<char>>>),
+    /// Foreground color of text run content.
+    pub fg: Rgb,
+    /// Background color of text run content.
+    pub bg: Rgb,
+    /// Background color opacity of the text run.
+    pub bg_alpha: f32,
+    /// Attributes of this text run.
+    pub flags: Flags,
+    /// cached glyph and cell for rendering.
+    pub data: Option<Vec<(RenderableCell, Glyph)>>,
+}
+
+impl Hash for TextRun {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (self.span.1 - self.span.0).hash(state);
+        self.content.hash(state);
+        self.flags.hash(state);
+    }
+}
+
+impl PartialEq for TextRun {
+    fn eq(&self, other: &Self) -> bool {
+        (self.span.1 - self.span.0) == (other.span.1 - other.span.0)
+            && self.content == other.content
+            && self.flags == other.flags
+    }
+}
+
+impl Eq for TextRun {}
+
+impl TextRun {
+    #[inline]
+    pub fn update_to_data(&mut self, other: &mut Self) {
+        if let Some(data) = &mut other.data {
+            if other.line != self.line {
+                other.line = self.line;
+                for (cell, _) in data.iter_mut() {
+                    cell.line = self.line;
+                }
+            }
+            let start = other.span.0;
+            if start != self.span.0 {
+                other.span = self.span;
+                for (cell, _) in data.iter_mut() {
+                    cell.column = self.span.0 + cell.column - start;
+                }
+            }
+            if other.fg != self.fg {
+                other.fg = self.fg;
+                for (cell, _) in data.iter_mut() {
+                    cell.fg = self.fg;
+                }
+            }
+            if other.bg != self.bg {
+                other.bg = self.bg;
+                for (cell, _) in data.iter_mut() {
+                    cell.bg = self.bg;
+                }
+            }
+            if other.bg_alpha.to_bits() != self.bg_alpha.to_bits() {
+                other.bg_alpha = self.bg_alpha;
+                for (cell, _) in data.iter_mut() {
+                    cell.bg_alpha = self.bg_alpha;
+                }
+            }
+        }
+    }
+
+    /// Returns dummy RenderableCell containing no content with positioning and color information
+    /// from this TextRun.
+    #[inline]
+    fn dummy_cell_at(&self, col: Column) -> RenderableCell {
+        RenderableCell {
+            line: self.line,
+            column: col,
+            character: ' ',
+            zerowidth: None,
+            fg: self.fg,
+            bg: self.bg,
+            bg_alpha: self.bg_alpha,
+            flags: self.flags,
+            is_match: false,
+        }
+    }
+
+    /// First cell in the TextRun
+    #[inline]
+    pub fn start_cell(&self) -> RenderableCell {
+        self.dummy_cell_at(self.span.0)
+    }
+
+    /// First point covered by this TextRun
+    #[inline]
+    pub fn start_point(&self) -> Point {
+        Point { line: self.line, col: self.span.0 }
+    }
+
+    /// End point covered by this TextRun
+    #[inline]
+    pub fn end_point(&self) -> Point {
+        Point { line: self.line, col: self.span.1 }
+    }
+}

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -1,8 +1,6 @@
 //! TTY related functionality.
 
 use std::borrow::Cow;
-#[cfg(not(target_os = "macos"))]
-use std::env;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io;
@@ -148,7 +146,7 @@ fn default_shell(pw: &Passwd<'_>) -> Program {
 
 #[cfg(not(target_os = "macos"))]
 fn default_shell(pw: &Passwd<'_>) -> Program {
-    Program::Just(env::var("SHELL").unwrap_or_else(|_| pw.shell.to_owned()))
+    Program::Just(std::env::var("SHELL").unwrap_or_else(|_| pw.shell.to_owned()))
 }
 
 /// Create a new TTY and return a handle to interact with it.

--- a/performance.md
+++ b/performance.md
@@ -1,0 +1,94 @@
+## ligature branch
+
+vtebench bytes: 30,000,000
+
+ Performance counter stats for 'cat scrolling.vte' (5 runs):
+
+       4317.121510      task-clock:u (msec)       #    0.993 CPUs utilized            ( +-  0.19% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                54      page-faults:u             #    0.012 K/sec                    ( +-  0.75% )
+         1,697,438      cycles:u                  #    0.000 GHz                      ( +-  1.90% )
+           266,640      instructions:u            #    0.16  insn per cycle           ( +-  0.00% )
+            61,669      branches:u                #    0.014 M/sec                    ( +-  0.00% )
+             4,687      branch-misses:u           #    7.60% of all branches          ( +-  1.30% )
+
+            4.3466 +- 0.0105 seconds time elapsed  ( +-  0.24% )
+
+vtebench bytes: 100,000,000
+
+ Performance counter stats for 'cat alt-screen-random-write.vte' (5 runs):
+
+        454.356267      task-clock:u (msec)       #    0.302 CPUs utilized            ( +-  0.06% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                54      page-faults:u             #    0.118 K/sec                    ( +-  0.91% )
+         2,924,607      cycles:u                  #    0.006 GHz                      ( +-  1.45% )
+           381,985      instructions:u            #    0.13  insn per cycle           ( +-  0.00% )
+            91,574      branches:u                #    0.202 M/sec                    ( +-  0.00% )
+             7,166      branch-misses:u           #    7.83% of all branches          ( +-  1.90% )
+
+           1.50589 +- 0.00999 seconds time elapsed  ( +-  0.66% )
+
+vtebench bytes: 30,000,000
+
+ Performance counter stats for 'cat scrolling-in-region.vte' (5 runs):
+
+       4334.702997      task-clock:u (msec)       #    0.997 CPUs utilized            ( +-  0.17% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                53      page-faults:u             #    0.012 K/sec                    ( +-  0.75% )
+         1,678,038      cycles:u                  #    0.000 GHz                      ( +-  4.07% )
+           266,656      instructions:u            #    0.16  insn per cycle           ( +-  0.00% )
+            61,672      branches:u                #    0.014 M/sec                    ( +-  0.00% )
+             4,690      branch-misses:u           #    7.60% of all branches          ( +-  1.10% )
+
+            4.3494 +- 0.0115 seconds time elapsed  ( +-  0.26% )
+
+## master branch
+
+vtebench bytes: 30,000,000
+
+ Performance counter stats for 'cat scrolling.vte' (5 runs):
+
+       4510.300996      task-clock:u (msec)       #    0.990 CPUs utilized            ( +-  0.44% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                54      page-faults:u             #    0.012 K/sec                    ( +-  0.70% )
+         1,912,596      cycles:u                  #    0.000 GHz                      ( +-  3.33% )
+           266,726      instructions:u            #    0.14  insn per cycle           ( +-  0.00% )
+            61,695      branches:u                #    0.014 M/sec                    ( +-  0.00% )
+             4,728      branch-misses:u           #    7.66% of all branches          ( +-  2.18% )
+
+            4.5571 +- 0.0312 seconds time elapsed  ( +-  0.69% )
+
+vtebench bytes: 100,000,000
+
+ Performance counter stats for 'cat alt-screen-random-write.vte' (5 runs):
+
+        455.743254      task-clock:u (msec)       #    0.299 CPUs utilized            ( +-  0.24% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                54      page-faults:u             #    0.118 K/sec                    ( +-  0.95% )
+         2,839,043      cycles:u                  #    0.006 GHz                      ( +-  1.64% )
+           381,985      instructions:u            #    0.13  insn per cycle           ( +-  0.00% )
+            91,574      branches:u                #    0.201 M/sec                    ( +-  0.00% )
+             6,990      branch-misses:u           #    7.63% of all branches          ( +-  1.24% )
+
+           1.52661 +- 0.00374 seconds time elapsed  ( +-  0.24% )
+
+vtebench bytes: 30,000,000
+
+ Performance counter stats for 'cat scrolling-in-region.vte' (5 runs):
+
+       4247.071459      task-clock:u (msec)       #    0.997 CPUs utilized            ( +-  0.55% )
+                 0      context-switches:u        #    0.000 K/sec
+                 0      cpu-migrations:u          #    0.000 K/sec
+                53      page-faults:u             #    0.012 K/sec                    ( +-  0.93% )
+         1,742,107      cycles:u                  #    0.000 GHz                      ( +-  2.26% )
+           266,656      instructions:u            #    0.15  insn per cycle           ( +-  0.00% )
+            61,672      branches:u                #    0.015 M/sec                    ( +-  0.00% )
+             4,601      branch-misses:u           #    7.46% of all branches          ( +-  1.89% )
+
+            4.2583 +- 0.0243 seconds time elapsed  ( +-  0.57% )
+


### PR DESCRIPTION
fix url detection

fix selected wide_char display issue

remove submodule and patch with git url

performance improvement and add benchmark result

- remove the use of drain. use split_off for better performance
- eliminate unnecessary copies
- compare the latest master branch with current ligature branch and
record in performance.md

several bugfix and performance updates:

- improve performance when ligature is disabled (render_timer almost the same as upstream)
- fix bug getting font face
- optimize text_run, remove the cells function and shape_run.
- RenderableCell now all passed in as references
- replace '\t' with ' '

cache the RenderableCell and Glyph to make rendering faster

remove RenderableCellIter and replace with TextRunIter

improve performance in first iteration

move assignment of data into renderer

improve performance, fix fg color of cursor

improve render time when resizing the window

fix version for harfbuzz, fix trait impl in Rasterizer

remove geuss_segment_properties since it will be called on shape

Fix: compilation in mac and windows

Feature: allow macos to use ligature. fix compilation error

upgrade harfbuzz-rs

Fix memory leak

use usize width in LatestCol to prevent additional if-condition

Feature: show fps in title bar

unlock windows ligature

Fix: filter non-file config paths for monitoring

ligatures setting default on